### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,5 @@ GitHub user tokens are AES encrypted with an At Rest Encryption Key configured i
 ## Development
 
 This plugin contains both a server and web app portion. Read our documentation about the [Developer Workflow](https://developers.mattermost.com/extend/plugins/developer-workflow/) and [Developer Setup](https://developers.mattermost.com/extend/plugins/developer-setup/) for more information about developing and extending plugins.
+
+


### PR DESCRIPTION
<details>
   <summary>Vulnerabilities fixed</summary>
   <p><em>Sourced from <a href="https://github.com/advisories/GHSA-43f8-2h32-f4cj">The GitHub Security Advisory Database</a>.</em></p>
   <blockquote>
      <p><strong>Regular Expression Denial of Service in hosted-git-info</strong>
         The npm package <code>hosted-git-info</code> before 3.0.8 are vulnerable to Regular Expression Denial of Service (ReDoS) via regular expression shortcutMatch in the fromUrl function in index.js. The affected regular expression exhibits polynomial worst-case time complexity
      </p>
      <p>Affected versions: &lt; 2.8.9</p>
   </blockquote>
</details>