### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Mattermost GitHub Plugin
 
+
+
 [![Build Status](https://img.shields.io/circleci/project/github/mattermost/mattermost-plugin-github/master.svg)](https://circleci.com/gh/mattermost/mattermost-plugin-github)
 [![Code Coverage](https://img.shields.io/codecov/c/github/mattermost/mattermost-plugin-github/master.svg)](https://codecov.io/gh/mattermost/mattermost-plugin-github)
 [![Release](https://img.shields.io/github/v/release/mattermost/mattermost-plugin-github)](https://github.com/mattermost/mattermost-plugin-github/releases/latest)


### PR DESCRIPTION
<details>
<summary>Vulnerabilities fixed</summary>
<p><em>Sourced from <a href="https://github.com/advisories/GHSA-43f8-2h32-f4cj">The GitHub Security Advisory Database</a>.</em></p>
<blockquote>
<p><strong>Regular Expression Denial of Service in hosted-git-info</strong>
The npm package <code>hosted-git-info</code> before 3.0.8 are vulnerable to Regular Expression Denial of Service (ReDoS) via regular expression shortcutMatch in the fromUrl function in index.js. The affected regular expression exhibits polynomial worst-case time complexity</p>
<p>Affected versions: &lt; 2.8.9</p>
</blockquote>
</details>